### PR TITLE
Add Google AdSense script

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,8 @@
     <meta name="theme-color" content="#ffffff">
 
     <script src="https://kit.fontawesome.com/b0e45b6dae.js"></script>
+    <script data-ad-client="pub-4718922828481704" async src="https://pagead2.googlesyndication
+.com/pagead/js/adsbygoogle.js"></script>
   </head>
   <body>
     <header>


### PR DESCRIPTION
Add code for Google Adsense. This is not for use of ads on our homepage but as a necessary step to enable ads on the research subdomain.